### PR TITLE
add ability to build new vrt file to more easily analyze different tiles

### DIFF
--- a/Sentinel1-RTC-example.ipynb
+++ b/Sentinel1-RTC-example.ipynb
@@ -186,8 +186,8 @@
     "# Create a VRT that points to all files in separate bands\n",
     "# Seems to take <30seconds for ~200 Tifs\n",
     "vrtName = f'stack{zone}{latLabel}{square}.vrt'\n",
-    "#cmd = f'gdalbuildvrt -overwrite -separate -input_file_list s3paths.txt {vrtName}'\n",
-    "#!{cmd}"
+    "cmd = f'gdalbuildvrt -overwrite -separate -input_file_list s3paths.txt {vrtName}'\n",
+    "!{cmd}"
    ]
   },
   {
@@ -197,9 +197,9 @@
    "outputs": [],
    "source": [
     "# Customize the VRT adding date to metadata\n",
-    "#with rasterio.open(vrtName, 'r+') as src:\n",
-    "#    print(f'adding filenames to {vrtName} band descriptions')\n",
-    "#    src.descriptions = files\n",
+    "with rasterio.open(vrtName, 'r+') as src:\n",
+    "    print(f'adding filenames to {vrtName} band descriptions')\n",
+    "    src.descriptions = files\n",
     "    # Or add as a metadata\n",
     "    #src.meta['date'] = files # doesn't work\n",
     "    #src.update_tags(date=files) # adds   <Metadata> <MDI key=\"date\">   "

--- a/Sentinel1-RTC-example.ipynb
+++ b/Sentinel1-RTC-example.ipynb
@@ -170,6 +170,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# creating s3paths.txt with /vsis/ prefix for gdalbuiltvrt, see: https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files\n",
+    "with open('s3paths.txt', 'w') as f:\n",
+    "    for key in keys:\n",
+    "        f.write(\"/vsis3/%s\\n\" % key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#%%time\n",
     "# Create a VRT that points to all files in separate bands\n",
     "# Seems to take <30seconds for ~200 Tifs\n",
@@ -469,9 +481,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:notebook] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-notebook-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Added a cell to create the text input file for gdalbuiltvrt when changing the tile of interest, as well as uncommented vrt creation and metadata addition. This makes it easier to change the tile to be analyzed by simply changing the tile information in the 4th code cell.